### PR TITLE
Remove is-stream dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,13 @@ import {Buffer} from 'node:buffer';
 import {Readable} from 'node:stream';
 import decompressTar from '@xhmikosr/decompress-tar';
 import {fileTypeFromBuffer} from 'file-type';
-import {isStream} from 'is-stream';
 import xzDecompress from 'xz-decompress';
 
 const decompressTarXz = () => async input => {
 	const isBuffer = Buffer.isBuffer(input);
 
-	if (!isBuffer && !isStream(input)) {
-		throw new TypeError(`Expected a Buffer or Stream, got ${typeof input}`);
+	if (!isBuffer && !(input instanceof Readable)) {
+		throw new TypeError(`Expected a Buffer or Readable stream, got ${typeof input}`);
 	}
 
 	if (isBuffer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@xhmikosr/decompress-tar": "^9.0.1",
         "file-type": "^21.3.4",
-        "is-stream": "^4.0.1",
         "xz-decompress": "^0.2.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@xhmikosr/decompress-tar": "^9.0.1",
     "file-type": "^21.3.4",
-    "is-stream": "^4.0.1",
     "xz-decompress": "^0.2.3"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -37,7 +37,7 @@ test('return empty array if non-valid file is supplied', async t => {
 });
 
 test('throw on wrong input', async t => {
-	await t.throwsAsync(decompressTarXz()('foo'), {message: 'Expected a Buffer or Stream, got string'});
+	await t.throwsAsync(decompressTarXz()('foo'), {message: 'Expected a Buffer or Readable stream, got string'});
 });
 
 test('many parallel decompressions', async t => {


### PR DESCRIPTION
Replace the is-stream check with a native `instanceof Readable` check. The input is only ever consumed via `Readable.toWeb()`, so it must be a Node Readable stream anyway.

/CC @felipecrs 

PS. I plan to include the plugin by default in my decompress fork soon :)